### PR TITLE
What does the dog say?

### DIFF
--- a/src/dog.c
+++ b/src/dog.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,14 +8,19 @@
 #include "functions.h"
 #include "dogos.h"
 
+static const uint8_t MAX_SIZE_BARK = 64;
+static const uint8_t MAX_SIZE_VERSION = 24;
+static const uint8_t MAX_SIZE_RENDER = 64;
+
 int main(int argc, char *argv[]) {
-	
-	char* bark = "Whoof!";
-	char dog_version[255];
+
+	char bark[MAX_SIZE_BARK];
+	char dog_version[MAX_SIZE_VERSION];
 	int opt;
 	int long_index = 0;
 
-	sprintf(dog_version, "Dog, v%s", version);
+	snprintf(bark, MAX_SIZE_BARK, "%s", "Whoof!");
+	snprintf(dog_version, MAX_SIZE_VERSION, "Dog, v%s", version);
 
 	static struct option long_options[] = {
 		{"help", no_argument, 0, 'h'},
@@ -51,7 +57,7 @@ int main(int argc, char *argv[]) {
 					break;
 
 				case 'b':
-					bark = "Bork!";
+					snprintf(bark, MAX_SIZE_BARK, "%s", "Bork!");
 					render(bark, true);
 					break;
 
@@ -60,12 +66,12 @@ int main(int argc, char *argv[]) {
 					break;
 
 				case 'g':
-					bark = "Guau!";
+					snprintf(bark, MAX_SIZE_BARK, "%s", "Guau!");
 					render(bark, true);
 					break;
 
 				case 'm':
-					bark = optarg;
+					snprintf(bark, MAX_SIZE_BARK, "%s", optarg);
 					render(bark, true);
 					break;
 
@@ -74,7 +80,7 @@ int main(int argc, char *argv[]) {
 					break;
 
 				case 'w':
-					bark = "Whoof whoof whoof!!";
+					snprintf(bark, MAX_SIZE_BARK, "%s", "Whoof whoof whoof!!");
 					render(bark, true);
 					break;	
 			}
@@ -85,15 +91,15 @@ int main(int argc, char *argv[]) {
 }
 
 void render(char* bark, int finish) {
-	char buffer[255];
+	char buffer[MAX_SIZE_RENDER];
 
 	for (int i = 0; i<5; i++) {
 		if (i != 2) {
-			sprintf(buffer, "%s\n", dog_one[i]);
+			snprintf(buffer, MAX_SIZE_RENDER, "%s", dog_one[i]);
 		} else {
-			sprintf(buffer, "%s  %s\n", dog_one[i], bark);
+			snprintf(buffer, MAX_SIZE_RENDER, "%s  %s", dog_one[i], bark);
 		}
-		printf("%s", buffer);
+		printf("%s\n", buffer);
 	}
 	if(finish == true) {
 		exit(0);
@@ -122,6 +128,17 @@ void renderFile(char* filepath) {
     exit(EXIT_SUCCESS);
 }
 
+// Note: This Function is not used
+//
+// Note: In this function you are allocating dynamic memory multiple times.
+//       You must free this memory, it is like constantly kick the dog, at
+//       some point, the dog will bite you. Also, avoid returning a
+//       dynamically allocated data outside the function, nobody outside know
+//       it is dynamic and must free it.
+//
+// Note: strcpy(), strcat(), sprintf() functions are unsafe (it easy to write
+//       outside the reserved memory using it), it is better to use a safest
+//       functions like strncpy(), stncat() and snprintf().
 char* paramsToString(int argc, char *argv[]) {
 	if(argc < 1) {
 		return "";
@@ -133,10 +150,14 @@ char* paramsToString(int argc, char *argv[]) {
 	if(argc > 1) {
 		for(int i = 2; i < argc; i++) {
 			char* tmp = (char*) malloc(strlen(ret) + strlen(argv[i]) + 1);
+			// You should check if the allocation fails
+			//if (tmp == NULL)
+			//    continue;
 			strcpy(tmp, ret);
 			strcat(tmp, " ");
 			strcat(tmp, argv[i]);
 			strcpy(ret, tmp);
+			//free(tmp); // You must free this in each iteration
 		}
 	}
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -8,6 +8,8 @@ void render(char* bark, int finish);
 void renderFile(char* filepath);
 char* paramsToString(int argc, char *argv[]);
 
+// A header file shouldn't implements functions, just define the function
+// prototype/interface (this function should be moved to dog.c)
 void clearScreen()
 {
   const char *CLEAR_SCREEN_ANSI = "\e[1;1H\e[2J";


### PR DESCRIPTION
## Description

Some code revision and changes to safest way to handle strings and memory...

## Changes

I have see the use of some **char*** pointers pointing to **literal strings**, something like:

```c++
char* bark = "Whoof!";
...
bark = "Bork!";
```

This is something that works but is not recommended, due string literals ("Whoof!" and "Bork!" in this case) shouldn't be modified, otherwise it can cause some **Undefined Behavior** (the beauty of dangerous C). There is no problem here because you are just pointing the *bark* pointer to one or another string literal (not modifying it), but it is recommended to avoid it usage (i.e. someone could try to sprintf(), strcpy(), or just assign bark[0] = 'c', modifiying the string literal that is currently pointing and causing the Undefined Behaviour).

A better way to handle this is to use a fixed size array instead a pointer (for this, some constant has been placed to specify MAX_SIZE of different arrays used in the code), and initializing and changin the data that it store by using snprintf() function... And here we are with the snprintf() function instead sprintf()...

In C there is some standard functions to work with strings, sprintf(), strcpy, strcat, strcmp(), etc. However, all this functions has the lack of secure checks when the source string are being copied to target string, if the source string is larger than the target one, all the source data will be written to target string even the bytes that are out of the target length, and this bytes will be written in unexpected memory region outside the target string... This is called **buffer overflow** and to avoid that this could happen by mistake, there is a better alternative functions, that could be considered an evolution of this other, the snprintf(), strncpy(), strncat(), strncmp(), etc. that are better recommended to be used instead (also there is some other even more secure functions, like ).

Regards.